### PR TITLE
Adding a needed requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml
 requests
 PyGObject
 psutil
+tqdm


### PR DESCRIPTION
Installed on a clean Linux Mint 20.3 machine, needed the package "tqdm". I added it in the requirements.txt on my machine, retry the python installation process and could it started.